### PR TITLE
Refactor proxy service into subpackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,23 +87,25 @@ The Config file is merge from usque's flags and configs, You can find the descri
     "bind_address": "0.0.0.0",
     "port": "2333",
     "username": "",
-    "password": "",
+    "password": ""
+  },
+  "tunnel": {
     "connect_port": 443,
     "dns": [
       "1.1.1.1",
       "8.8.8.8"
     ],
-    "dns_timeout": 2000000000,
+    "dns_timeout": "2s",
     "use_ipv6": false,
     "no_tunnel_ipv4": false,
     "no_tunnel_ipv6": false,
     "sni_address": "",
-    "keepalive_period": 30000000000,
+    "keepalive_period": "30s",
     "mtu": 1280,
     "initial_packet_size": 1242,
-    "reconnect_delay": 1000000000,
-    "connection_timeout": 30000000000,
-    "idle_timeout": 300000000000
+    "reconnect_delay": "1s",
+    "connection_timeout": "30s",
+    "idle_timeout": "5m"
   },
   "registration": {
     "device_name": "Device name"

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -2,25 +2,16 @@ package cmd
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"fmt"
 	"log"
-	"net"
-	"net/netip"
-	"os"
-	"runtime"
-	"time"
-
-	"github.com/HynoR/uscf/models"
 
 	"github.com/HynoR/uscf/api"
 	"github.com/HynoR/uscf/config"
 	"github.com/HynoR/uscf/internal"
+	proxysvc "github.com/HynoR/uscf/service/proxy"
+	"github.com/HynoR/uscf/service/tunnel"
 	"github.com/spf13/cobra"
-	"github.com/things-go/go-socks5"
-	"golang.zx2c4.com/wireguard/tun"
-	"golang.zx2c4.com/wireguard/tun/netstack"
 )
 
 // proxyCmd 命令，结合 socks 和 register 的功能
@@ -148,7 +139,8 @@ func runProxyCmd(cmd *cobra.Command, args []string) {
 	}
 
 	// 2. 启动 SOCKS5 代理
-	if err := setupAndRunSocksProxy(cmd); err != nil {
+	svc := proxysvc.New(tunnel.DefaultManager{})
+	if err := svc.Run(context.Background(), &config.AppConfig); err != nil {
 		cmd.Printf("%v\n", err)
 		return
 	}
@@ -219,270 +211,4 @@ func handleRegistration(cmd *cobra.Command, configPath string) error {
 	// 标记配置已加载
 	config.ConfigLoaded = true
 	return nil
-}
-
-// setupAndRunSocksProxy 设置并运行SOCKS5代理
-func setupAndRunSocksProxy(cmd *cobra.Command) error {
-	log.Println("Starting SOCKS5 proxy...")
-
-	// 设置最大并发处理能力
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
-	// 准备TLS配置
-	tlsConfig, err := prepareTlsConfig(cmd)
-	if err != nil {
-		return err
-	}
-
-	// 准备网络配置
-	endpoint, localAddresses, dnsAddrs, err := prepareNetworkConfig(cmd)
-	if err != nil {
-		return err
-	}
-
-	// 获取超时设置
-	connectionTimeout, idleTimeout := getTimeoutSettings(cmd)
-
-	// 创建TUN设备
-	tunDev, tunNet, err := createTunDevice(localAddresses, dnsAddrs, cmd)
-	if err != nil {
-		return err
-	}
-	defer tunDev.Close()
-
-	// 配置连接并启动隧道
-	startTunnel(cmd, tlsConfig, endpoint, tunDev)
-
-	// 创建并启动SOCKS服务器
-	return runSocksServer(cmd, tunNet, connectionTimeout, idleTimeout)
-}
-
-// prepareTlsConfig 准备TLS配置
-func prepareTlsConfig(cmd *cobra.Command) (*tls.Config, error) {
-	// 从配置中获取SNI地址
-	sni := config.AppConfig.Socks.SNIAddress
-
-	privKey, err := config.AppConfig.GetEcPrivateKey()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get private key: %v", err)
-	}
-	peerPubKey, err := config.AppConfig.GetEcEndpointPublicKey()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get public key: %v", err)
-	}
-
-	cert, err := internal.GenerateCert(privKey, &privKey.PublicKey)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to generate cert: %v", err)
-	}
-
-	tlsConfig, err := api.PrepareTlsConfig(privKey, peerPubKey, cert, sni)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to prepare TLS config: %v", err)
-	}
-	return tlsConfig, nil
-}
-
-// prepareNetworkConfig 准备网络配置
-func prepareNetworkConfig(cmd *cobra.Command) (*net.UDPAddr, []netip.Addr, []netip.Addr, error) {
-	// 从配置文件获取连接端口
-	connectPort := config.AppConfig.Socks.ConnectPort
-
-	// 确定使用IPv4还是IPv6端点
-	var endpoint *net.UDPAddr
-	if !config.AppConfig.Socks.UseIPv6 {
-		endpoint = &net.UDPAddr{
-			IP:   net.ParseIP(config.AppConfig.EndpointV4),
-			Port: connectPort,
-		}
-	} else {
-		endpoint = &net.UDPAddr{
-			IP:   net.ParseIP(config.AppConfig.EndpointV6),
-			Port: connectPort,
-		}
-	}
-
-	// 隧道内IP设置
-	var localAddresses []netip.Addr
-	if !config.AppConfig.Socks.NoTunnelIPv4 {
-		v4, err := netip.ParseAddr(config.AppConfig.IPv4)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("Failed to parse IPv4 address: %v", err)
-		}
-		localAddresses = append(localAddresses, v4)
-	}
-	if !config.AppConfig.Socks.NoTunnelIPv6 {
-		v6, err := netip.ParseAddr(config.AppConfig.IPv6)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("Failed to parse IPv6 address: %v", err)
-		}
-		localAddresses = append(localAddresses, v6)
-	}
-
-	// DNS设置
-	var dnsAddrs []netip.Addr
-	for _, dns := range config.AppConfig.Socks.DNS {
-		addr, err := netip.ParseAddr(dns)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("Failed to parse DNS server: %v", err)
-		}
-		dnsAddrs = append(dnsAddrs, addr)
-	}
-
-	return endpoint, localAddresses, dnsAddrs, nil
-}
-
-// getTimeoutSettings 获取超时设置
-func getTimeoutSettings(cmd *cobra.Command) (time.Duration, time.Duration) {
-	// 直接从配置文件中读取超时设置
-	connectionTimeout := config.AppConfig.Socks.ConnectionTimeout
-	idleTimeout := config.AppConfig.Socks.IdleTimeout
-
-	// 确保设置了默认值
-	if connectionTimeout == 0 {
-		connectionTimeout = 30 * time.Second
-	}
-
-	if idleTimeout == 0 {
-		idleTimeout = 5 * time.Minute
-	}
-
-	return connectionTimeout, idleTimeout
-}
-
-// createTunDevice 创建TUN设备
-func createTunDevice(localAddresses, dnsAddrs []netip.Addr, cmd *cobra.Command) (tun.Device, *netstack.Net, error) {
-	// 从配置中获取MTU
-	mtu := config.AppConfig.Socks.MTU
-	if mtu != 1280 {
-		log.Println("Warning: MTU is not the default 1280. This is not supported. Packet loss and other issues may occur.")
-	}
-
-	tunDev, tunNet, err := netstack.CreateNetTUN(localAddresses, dnsAddrs, mtu)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to create virtual TUN device: %v", err)
-	}
-	return tunDev, tunNet, nil
-}
-
-// startTunnel 配置并启动隧道连接
-func startTunnel(cmd *cobra.Command, tlsConfig *tls.Config, endpoint *net.UDPAddr, tunDev tun.Device) {
-	// 从配置文件读取隧道参数
-	keepalivePeriod := config.AppConfig.Socks.KeepalivePeriod
-	initialPacketSize := config.AppConfig.Socks.InitialPacketSize
-	mtu := config.AppConfig.Socks.MTU
-	reconnectDelay := config.AppConfig.Socks.ReconnectDelay
-
-	configTunnel := api.ConnectionConfig{
-		TLSConfig:         tlsConfig,
-		KeepAlivePeriod:   keepalivePeriod,
-		InitialPacketSize: initialPacketSize,
-		Endpoint:          endpoint,
-		MTU:               mtu,
-		MaxPacketRate:     8192,
-		MaxBurst:          1024,
-		ReconnectStrategy: &api.ExponentialBackoff{
-			InitialDelay: reconnectDelay,
-			MaxDelay:     5 * time.Minute,
-			Factor:       2.0,
-		},
-	}
-
-	go api.MaintainTunnel(
-		context.Background(),
-		configTunnel,
-		api.NewNetstackAdapter(tunDev),
-	)
-}
-
-// runSocksServer 创建并运行SOCKS5服务器
-func runSocksServer(cmd *cobra.Command, tunNet *netstack.Net, connectionTimeout, idleTimeout time.Duration) error {
-	// 从配置中获取网络参数
-	bindAddress := config.AppConfig.Socks.BindAddress
-	port := config.AppConfig.Socks.Port
-
-	// 创建本地DNS解析器
-	// api.NewCachingDNSResolver需要一个int类型的超时值（秒数）
-	dnsTimeout := config.AppConfig.Socks.DNSTimeout
-	dnsTimeoutSeconds := int(dnsTimeout.Seconds())
-	localResolver := api.NewCachingDNSResolver("", dnsTimeoutSeconds)
-
-	// 添加超时设置的拨号函数
-	dialFunc := func(ctx context.Context, network, addr string) (net.Conn, error) {
-		dialCtx, cancel := context.WithTimeout(ctx, connectionTimeout)
-		defer cancel()
-
-		conn, err := tunNet.DialContext(dialCtx, network, addr)
-		if err != nil {
-			return nil, err
-		}
-
-		return &models.TimeoutConn{
-			Conn:        conn,
-			IdleTimeout: idleTimeout,
-		}, nil
-	}
-
-	// 从配置中获取身份验证设置
-	username := config.AppConfig.Socks.Username
-	password := config.AppConfig.Socks.Password
-
-	// 创建SOCKS5服务器
-	server := createSocksServer(username, password, dialFunc, localResolver)
-
-	// 启动监听
-	log.Printf("SOCKS proxy listening on %s:%s with timeouts (connect: %s, idle: %s)",
-		bindAddress, port, connectionTimeout, idleTimeout)
-
-	listener, err := net.Listen("tcp", net.JoinHostPort(bindAddress, port))
-	if err != nil {
-		return fmt.Errorf("Failed to start SOCKS proxy: %v", err)
-	}
-
-	for {
-		conn, err := listener.Accept()
-		if err != nil {
-			log.Printf("Failed to accept connection: %v\n", err)
-			continue
-		}
-
-		timeoutConn := &models.TimeoutConn{
-			Conn:        conn,
-			IdleTimeout: idleTimeout,
-		}
-
-		go server.ServeConn(timeoutConn)
-	}
-}
-
-// createSocksServer 创建SOCKS5服务器
-func createSocksServer(username, password string, dialFunc func(ctx context.Context, network, addr string) (net.Conn, error), resolver socks5.NameResolver) *socks5.Server {
-	buf := api.NewNetBuffer(32 * 1024) // 32KB buffer
-	if buf == nil {
-		log.Println("Failed to create buffer")
-		return nil
-	}
-
-	if username == "" || password == "" {
-		return socks5.NewServer(
-			socks5.WithLogger(socks5.NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
-			socks5.WithDial(dialFunc),
-			socks5.WithResolver(resolver),
-			socks5.WithBufferPool(buf),
-		)
-	} else {
-
-		return socks5.NewServer(
-			socks5.WithLogger(socks5.NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
-			socks5.WithDial(dialFunc),
-			socks5.WithResolver(resolver),
-			socks5.WithAuthMethods([]socks5.Authenticator{
-				socks5.UserPassAuthenticator{
-					Credentials: socks5.StaticCredentials{
-						username: password,
-					},
-				}}),
-			socks5.WithBufferPool(buf),
-		)
-	}
 }

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -71,7 +71,7 @@ func runProxyCmd(cmd *cobra.Command, args []string) {
 		}
 
 		// 更新一些需要从内部常量获取的配置值
-		config.AppConfig.Socks.SNIAddress = internal.ConnectSNI
+		config.AppConfig.Tunnel.SNIAddress = internal.ConnectSNI
 
 		// 保存更新后的配置
 		if err := config.AppConfig.SaveConfig(configPath); err != nil {
@@ -82,13 +82,14 @@ func runProxyCmd(cmd *cobra.Command, args []string) {
 		log.Println("Resetting SOCKS5 configuration to default values...")
 
 		// 保存当前的SNI地址，因为它取决于内部常量
-		sniAddress := config.AppConfig.Socks.SNIAddress
+		sniAddress := config.AppConfig.Tunnel.SNIAddress
 
 		// 重置为默认配置
 		config.AppConfig.Socks = config.GetDefaultSocksConfig()
+		config.AppConfig.Tunnel = config.GetDefaultTunnelConfig()
 
 		// 恢复SNI地址
-		config.AppConfig.Socks.SNIAddress = sniAddress
+		config.AppConfig.Tunnel.SNIAddress = sniAddress
 
 		// 保存更新后的配置
 		if err := config.AppConfig.SaveConfig(configPath); err != nil {

--- a/service/proxy/service.go
+++ b/service/proxy/service.go
@@ -1,0 +1,42 @@
+package proxy
+
+import (
+	"context"
+
+	"github.com/HynoR/uscf/config"
+	"github.com/HynoR/uscf/service/socks"
+	"github.com/HynoR/uscf/service/tunnel"
+)
+
+// Service coordinates the SOCKS proxy and MASQUE tunnel.
+type Service struct {
+	Tunnel tunnel.Manager
+}
+
+// New creates a Service with the given tunnel manager.
+func New(m tunnel.Manager) *Service {
+	return &Service{Tunnel: m}
+}
+
+// Run initializes and starts the MASQUE tunnel and SOCKS proxy.
+func (s *Service) Run(ctx context.Context, cfg *config.Config) error {
+	tlsCfg, err := tunnel.PrepareTLSConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	endpoint, locals, dnsAddrs, err := tunnel.PrepareNetworkConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	connTimeout, idleTimeout := tunnel.TimeoutSettings(cfg)
+	dev, netTun, err := tunnel.CreateTun(locals, dnsAddrs, cfg)
+	if err != nil {
+		return err
+	}
+	defer dev.Close()
+
+	tunnel.StartTunnel(ctx, s.Tunnel, tlsCfg, endpoint, cfg, dev)
+	return socks.Run(cfg, netTun, connTimeout, idleTimeout)
+}

--- a/service/socks/server.go
+++ b/service/socks/server.go
@@ -1,0 +1,73 @@
+package socks
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"time"
+
+	"github.com/HynoR/uscf/api"
+	"github.com/HynoR/uscf/config"
+	"github.com/HynoR/uscf/models"
+	"github.com/things-go/go-socks5"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+)
+
+// Run starts a SOCKS5 server using the provided tunnel network stack.
+func Run(cfg *config.Config, tunNet *netstack.Net, connectionTimeout, idleTimeout time.Duration) error {
+	dnsTimeoutSec := int(cfg.Socks.DNSTimeout.Seconds())
+	resolver := api.NewCachingDNSResolver("", dnsTimeoutSec)
+
+	dialFunc := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dctx, cancel := context.WithTimeout(ctx, connectionTimeout)
+		defer cancel()
+
+		conn, err := tunNet.DialContext(dctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return &models.TimeoutConn{Conn: conn, IdleTimeout: idleTimeout}, nil
+	}
+
+	server := createServer(cfg.Socks.Username, cfg.Socks.Password, dialFunc, resolver)
+	bindAddr := net.JoinHostPort(cfg.Socks.BindAddress, cfg.Socks.Port)
+	log.Printf("SOCKS proxy listening on %s", bindAddr)
+
+	l, err := net.Listen("tcp", bindAddr)
+	if err != nil {
+		return fmt.Errorf("failed to start SOCKS proxy: %w", err)
+	}
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			log.Printf("Failed to accept connection: %v", err)
+			continue
+		}
+		timeoutConn := &models.TimeoutConn{Conn: conn, IdleTimeout: idleTimeout}
+		go server.ServeConn(timeoutConn)
+	}
+}
+
+func createServer(username, password string, dial func(ctx context.Context, network, addr string) (net.Conn, error), resolver socks5.NameResolver) *socks5.Server {
+	buf := api.NewNetBuffer(32 * 1024)
+	if buf == nil {
+		log.Println("Failed to create buffer")
+		return nil
+	}
+
+	opts := []socks5.Option{
+		socks5.WithLogger(socks5.NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
+		socks5.WithDial(dial),
+		socks5.WithResolver(resolver),
+		socks5.WithBufferPool(buf),
+	}
+	if username != "" && password != "" {
+		opts = append(opts, socks5.WithAuthMethods([]socks5.Authenticator{
+			socks5.UserPassAuthenticator{Credentials: socks5.StaticCredentials{username: password}},
+		}))
+	}
+	return socks5.NewServer(opts...)
+}

--- a/service/socks/server.go
+++ b/service/socks/server.go
@@ -17,7 +17,7 @@ import (
 
 // Run starts a SOCKS5 server using the provided tunnel network stack.
 func Run(cfg *config.Config, tunNet *netstack.Net, connectionTimeout, idleTimeout time.Duration) error {
-	dnsTimeoutSec := int(cfg.Socks.DNSTimeout.Seconds())
+	dnsTimeoutSec := int(cfg.Tunnel.DNSTimeout.Duration().Seconds())
 	resolver := api.NewCachingDNSResolver("", dnsTimeoutSec)
 
 	dialFunc := func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/service/tunnel/manager.go
+++ b/service/tunnel/manager.go
@@ -1,0 +1,19 @@
+package tunnel
+
+import (
+	"context"
+	"github.com/HynoR/uscf/api"
+)
+
+// Manager abstracts the tunnel maintenance logic so it can be easily mocked.
+type Manager interface {
+	MaintainTunnel(ctx context.Context, cfg api.ConnectionConfig, dev api.TunnelDevice)
+}
+
+// DefaultManager uses api.MaintainTunnel for production.
+type DefaultManager struct{}
+
+// MaintainTunnel implements Manager by delegating to api.MaintainTunnel.
+func (DefaultManager) MaintainTunnel(ctx context.Context, cfg api.ConnectionConfig, dev api.TunnelDevice) {
+	api.MaintainTunnel(ctx, cfg, dev)
+}

--- a/service/tunnel/setup.go
+++ b/service/tunnel/setup.go
@@ -1,0 +1,122 @@
+package tunnel
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net"
+	"net/netip"
+	"time"
+
+	"github.com/HynoR/uscf/api"
+	"github.com/HynoR/uscf/config"
+	"github.com/HynoR/uscf/internal"
+	"golang.zx2c4.com/wireguard/tun"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+)
+
+// PrepareTLSConfig creates a TLS configuration for the MASQUE tunnel.
+func PrepareTLSConfig(cfg *config.Config) (*tls.Config, error) {
+	privKey, err := cfg.GetEcPrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get private key: %w", err)
+	}
+
+	peerPubKey, err := cfg.GetEcEndpointPublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get public key: %w", err)
+	}
+
+	cert, err := internal.GenerateCert(privKey, &privKey.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate cert: %w", err)
+	}
+
+	tlsConfig, err := api.PrepareTlsConfig(privKey, peerPubKey, cert, cfg.Socks.SNIAddress)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare TLS config: %w", err)
+	}
+	return tlsConfig, nil
+}
+
+// PrepareNetworkConfig returns tunnel endpoint and address configuration.
+func PrepareNetworkConfig(cfg *config.Config) (*net.UDPAddr, []netip.Addr, []netip.Addr, error) {
+	var endpoint *net.UDPAddr
+	if cfg.Socks.UseIPv6 {
+		endpoint = &net.UDPAddr{IP: net.ParseIP(cfg.EndpointV6), Port: cfg.Socks.ConnectPort}
+	} else {
+		endpoint = &net.UDPAddr{IP: net.ParseIP(cfg.EndpointV4), Port: cfg.Socks.ConnectPort}
+	}
+
+	var locals []netip.Addr
+	if !cfg.Socks.NoTunnelIPv4 {
+		v4, err := netip.ParseAddr(cfg.IPv4)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to parse IPv4 address: %w", err)
+		}
+		locals = append(locals, v4)
+	}
+	if !cfg.Socks.NoTunnelIPv6 {
+		v6, err := netip.ParseAddr(cfg.IPv6)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to parse IPv6 address: %w", err)
+		}
+		locals = append(locals, v6)
+	}
+
+	var dnsAddrs []netip.Addr
+	for _, dns := range cfg.Socks.DNS {
+		addr, err := netip.ParseAddr(dns)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to parse DNS server: %w", err)
+		}
+		dnsAddrs = append(dnsAddrs, addr)
+	}
+
+	return endpoint, locals, dnsAddrs, nil
+}
+
+// TimeoutSettings returns the connection and idle timeout values.
+func TimeoutSettings(cfg *config.Config) (time.Duration, time.Duration) {
+	conn := cfg.Socks.ConnectionTimeout
+	idle := cfg.Socks.IdleTimeout
+	if conn == 0 {
+		conn = 30 * time.Second
+	}
+	if idle == 0 {
+		idle = 5 * time.Minute
+	}
+	return conn, idle
+}
+
+// CreateTun sets up the virtual network interface for the tunnel.
+func CreateTun(local, dns []netip.Addr, cfg *config.Config) (tun.Device, *netstack.Net, error) {
+	if cfg.Socks.MTU != 1280 {
+		log.Println("Warning: MTU is not the default 1280. Packet loss may occur")
+	}
+	dev, netTun, err := netstack.CreateNetTUN(local, dns, cfg.Socks.MTU)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create virtual TUN device: %w", err)
+	}
+	return dev, netTun, nil
+}
+
+// StartTunnel launches the MASQUE tunnel in a background goroutine.
+func StartTunnel(ctx context.Context, m Manager, tlsCfg *tls.Config, endpoint *net.UDPAddr, cfg *config.Config, dev tun.Device) {
+	conf := api.ConnectionConfig{
+		TLSConfig:         tlsCfg,
+		KeepAlivePeriod:   cfg.Socks.KeepalivePeriod,
+		InitialPacketSize: cfg.Socks.InitialPacketSize,
+		Endpoint:          endpoint,
+		MTU:               cfg.Socks.MTU,
+		MaxPacketRate:     8192,
+		MaxBurst:          1024,
+		ReconnectStrategy: &api.ExponentialBackoff{
+			InitialDelay: cfg.Socks.ReconnectDelay,
+			MaxDelay:     5 * time.Minute,
+			Factor:       2.0,
+		},
+	}
+	go m.MaintainTunnel(ctx, conf, api.NewNetstackAdapter(dev))
+}


### PR DESCRIPTION
## Summary
- move proxy runtime logic into subpackages `service/proxy`, `service/socks`, and `service/tunnel`
- refactor `ProxyService` to orchestrate tunnel setup and SOCKS server
- adjust CLI code to use new service structure

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_684cfd1a59c8832aa526f1b40c71de40