### PR TITLE
Add context-aware shutdown for SOCKS server

### DIFF
--- a/service/proxy/service.go
+++ b/service/proxy/service.go
@@ -38,5 +38,5 @@ func (s *Service) Run(ctx context.Context, cfg *config.Config) error {
 	defer dev.Close()
 
 	tunnel.StartTunnel(ctx, s.Tunnel, tlsCfg, endpoint, cfg, dev)
-	return socks.Run(cfg, netTun, connTimeout, idleTimeout)
+	return socks.Run(ctx, cfg, netTun, connTimeout, idleTimeout)
 }


### PR DESCRIPTION
## Summary
- accept a context in `socks.Run` and shut down the listener on cancellation
- pass context from `Service.Run` when launching the SOCKS server

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_6854cc01fffc832a8e3f12894166f57d