### PR TITLE
Add per-client tunnel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ You can also specify a log file path in the `logging.output_path` field and the 
     "initial_packet_size": 1242,
     "reconnect_delay": "1s",
     "connection_timeout": "30s",
-    "idle_timeout": "5m"
+    "idle_timeout": "5m",
+    "per_client": false
   },
   "logging": {
     "output_path": "",

--- a/config/config.go
+++ b/config/config.go
@@ -99,6 +99,7 @@ type TunnelConfig struct {
 	ReconnectDelay    Duration `json:"reconnect_delay"`     // 重连延迟
 	ConnectionTimeout Duration `json:"connection_timeout"`  // 建立连接超时
 	IdleTimeout       Duration `json:"idle_timeout"`        // 空闲连接超时
+	PerClient         bool     `json:"per_client"`          // 是否为每个SOCKS客户端创建独立隧道
 }
 
 // LoggingConfig contains configuration related to logging output.
@@ -184,6 +185,7 @@ func GetDefaultTunnelConfig() TunnelConfig {
 		ReconnectDelay:    Duration(1 * time.Second),
 		ConnectionTimeout: Duration(30 * time.Second),
 		IdleTimeout:       Duration(5 * time.Minute),
+		PerClient:         false,
 	}
 }
 

--- a/service/proxy/service.go
+++ b/service/proxy/service.go
@@ -31,6 +31,11 @@ func (s *Service) Run(ctx context.Context, cfg *config.Config) error {
 	}
 
 	connTimeout, idleTimeout := tunnel.TimeoutSettings(cfg)
+
+	if cfg.Tunnel.PerClient {
+		return socks.Run(ctx, cfg, nil, connTimeout, idleTimeout)
+	}
+
 	dev, netTun, err := tunnel.CreateTun(locals, dnsAddrs, cfg)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- allow configuration of per-client tunnel creation via `tunnel.per_client`
- spin up MASQUE tunnel for each SOCKS connection when enabled
- update proxy service to skip global tunnel when per-client mode is active
- document new config field

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_6854cf1576f8832aa6b4d4d63907412c